### PR TITLE
Small improvements for deb builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ since it is assumed that it will be called by other applications.
 ### How to build
 Installing the necessary deb packages.
 ``` bash
-sudo apt install g++ cmake uuid-dev libboost-all-dev
+sudo apt install g++ cmake uuid-dev libboost-program-options-dev libboost-filesystem-dev
 ```
 Or installing the necessary rpm packages.
 ``` bash
@@ -86,7 +86,7 @@ In the project, the library is used for tests.
 ### How to build
 Installing the necessary deb packages.
 ``` bash
-sudo apt install g++ cmake uuid-dev libboost-all-dev
+sudo apt install g++ cmake uuid-dev libboost-filesystem-dev
 ```
 Or installing the necessary rpm packages.
 ``` bash
@@ -116,7 +116,7 @@ build С++ tests.
 ### How to build
 Installing the necessary deb packages.
 ``` bash
-sudo apt install g++ cmake uuid-dev libboost-all-dev libssl-dev
+sudo apt install g++ cmake uuid-dev libboost-program-options-dev libboost-filesystem-dev libssl-dev
 ```
 Or installing the necessary rpm packages.
 ``` bash

--- a/pkg/deb/blksnap-dev/build.sh
+++ b/pkg/deb/blksnap-dev/build.sh
@@ -7,9 +7,10 @@ then
 else
 	VERSION="1.0.0.0"
 fi
-if [ -n "$2" ]
+
+if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
 then
-	ARCH="$2"
+	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
 else
 	ARCH="amd64"
 fi

--- a/pkg/deb/blksnap-dev/build.sh
+++ b/pkg/deb/blksnap-dev/build.sh
@@ -56,7 +56,7 @@ Source: ${NAME}
 Section: devel
 Priority: standard
 Maintainer: Veeam Software Group GmbH <veeam_team@veeam.com>
-Build-Depends: debhelper (>= 9.0.0), bash, g++, cmake, uuid-dev, libboost-all-dev
+Build-Depends: debhelper (>= 9.0.0), bash, g++, cmake, uuid-dev, libboost-filesystem-dev
 
 Package: ${NAME}
 Architecture: ${ARCH}

--- a/pkg/deb/blksnap-tests/build.sh
+++ b/pkg/deb/blksnap-tests/build.sh
@@ -7,9 +7,9 @@ then
 else
 	VERSION="1.0.0.0"
 fi
-if [ -n "$2" ]
+if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
 then
-	ARCH="$2"
+	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
 else
 	ARCH="amd64"
 fi

--- a/pkg/deb/blksnap-tests/build.sh
+++ b/pkg/deb/blksnap-tests/build.sh
@@ -62,7 +62,7 @@ Source: ${NAME}
 Section: utils
 Priority: standard
 Maintainer: Veeam Software Group GmbH <veeam_team@veeam.com>
-Build-Depends: debhelper (>= 9.0.0), bash, g++, cmake, uuid-dev, libboost-all-dev, libssl-dev
+Build-Depends: debhelper (>= 9.0.0), bash, g++, cmake, uuid-dev, libboost-program-options-dev, libboost-filesystem-dev, libssl-dev
 
 Package: ${NAME}
 Architecture: ${ARCH}

--- a/pkg/deb/blksnap-tools/build.sh
+++ b/pkg/deb/blksnap-tools/build.sh
@@ -7,9 +7,9 @@ then
 else
 	VERSION="1.0.0.0"
 fi
-if [ -n "$2" ]
+if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
 then
-	ARCH="$2"
+	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
 else
 	ARCH="amd64"
 fi

--- a/pkg/deb/blksnap-tools/build.sh
+++ b/pkg/deb/blksnap-tools/build.sh
@@ -23,7 +23,7 @@ rm -rf ${BUILD_DIR}
 mkdir -p ${BUILD_DIR}
 
 SOURCE_DIR="tools/blksnap/bin"
-TARGET_DIR="usr/bin"
+TARGET_DIR="usr/sbin"
 
 # build
 rm -rf ${SOURCE_DIR}/*

--- a/pkg/deb/blksnap-tools/build.sh
+++ b/pkg/deb/blksnap-tools/build.sh
@@ -56,7 +56,7 @@ Source: ${NAME}
 Section: admin
 Priority: standard
 Maintainer: Veeam Software Group GmbH <veeam_team@veeam.com>
-Build-Depends: debhelper (>= 9.0.0), g++, cmake, uuid-dev, libboost-all-dev
+Build-Depends: debhelper (>= 9.0.0), g++, cmake, uuid-dev, libboost-program-options-dev, libboost-filesystem-dev
 
 Package: ${NAME}
 Architecture: ${ARCH}

--- a/tests/blksnap.sh
+++ b/tests/blksnap.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0+
 
-if [ -f "/usr/bin/blksnap" ]
+if [ -f "/usr/bin/blksnap" ] || [ -f "/usr/sbin/blksnap" ]
 then
 	BLKSNAP=blksnap
 else


### PR DESCRIPTION
- deb package: automatically take arch with dpkg-architecture
- deb: install only libboost parts required instead all: this will decrease packages to install for build deb packages or
manually on debian and derivates