### PR TITLE
Add cicleci config with deb packages build for debian 11 and debian 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,57 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+shared: &shared
+    steps:
+      - checkout
+      - run:
+            name: Prepare environment
+            command: |
+                apt-get update
+                apt-get -y full-upgrade
+      - run:
+            name: Install dependencies
+            command: |
+                apt-get install -y g++ cmake uuid-dev libboost-program-options-dev libboost-filesystem-dev libssl-dev debhelper dkms
+      - run:
+            name: Build blksnap-dkms package
+            working_directory: pkg/deb/blksnap-dkms
+            command: ./build.sh
+      - run:
+            name: Build blksnap-tools package
+            working_directory: pkg/deb/blksnap-tools
+            command: ./build.sh
+      - run:
+            name: Build blksnap-dev package
+            working_directory: pkg/deb/blksnap-dev
+            command: ./build.sh
+      - run:
+            name: Build blksnap-tests package
+            working_directory: pkg/deb/blksnap-tests
+            command: ./build.sh
+      - run:
+            name: Save generate packages as artifacts
+            working_directory: build
+            command: |
+                mkdir /tmp/artifacts
+                mv *.deb /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/artifacts
+
+jobs:
+    debian11:
+        <<: *shared
+        docker:
+            - image: library/debian:bullseye
+
+    debian12:
+        <<: *shared
+        docker:
+            - image: library/debian:bookworm
+
+workflows:
+  build-install:
+    jobs:
+      - debian11
+      - debian12

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !.gitignore
 !.editorconfig
 !.clang-format
+!.circleci
 cmake*
 /build/
 /lib/blksnap/bin/


### PR DESCRIPTION
This make possible test build on debian 11 and debian 12 (now in
development) on any commit and it produce deb packages as artifact for
easy and fast download for users and testers.
It use the official debian build from dockerhub:
https://hub.docker.com/_/debian
There is official image also of debian 10, if needed can be added to
circleci config fast.

It require to give to circleci access to the repository.
As public repository the the free plan have 400000 public credits for
month and 2 gb of storage.
On test I done it built in 1 minutes and 21 seconds and deb packages
storage was 3.6mb, for the tests done for now I consumed 126 credits for
6 minutes of build for example.
So a free plans is enough for big amount of commits and PR and also
other distros jobs can be added.

Possible future additional to circleci jobs can be ubuntu:
https://hub.docker.com/_/ubuntu (official docker images and support all
LTS from 14.04 to 22.04 and next ubuntu in development 22.10)

Creating a job for build and store rpm packages, a support for distro
based on them can be added and probably fast/easy using official docker
images if present.