### PR TITLE
Create bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a bug report to help this improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+```
+ * Blksnap version (git commit used for build)
+   - Please specify if you are used external kernel module (built from module/
+     or with dkms packages) or the patch for upstream. In the case of the upstream
+     one specify the version of the patch or the git branch/commit used
+ * Distribution
+ * Architecture
+ ```
+
+**Describe the bug**
+Before create a new bug report search and check there isn't a duplicate already present.
+Provide a description of the bug you're found.
+Please don't expect anyone to guess everything but give enough information.
+
+**Steps to reproduce**
+Describe the steps to reproduce the bug (when possible).
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional informations**
+Add any additional information related to the issue here.


### PR DESCRIPTION
Minimal bug report template, in future can be improved with more informations that can help and link to howto for debugging, for example decode a backtrace or kernel panic before post them. Or also using issue form:
https://github.blog/changelog/2021-06-23-issues-forms-beta-for-public-repositories/