### PR TITLE
small improvements to stable-2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ shared: &shared
             command: ./build-blksnap.sh
       - run:
             name: Save generate packages as artifacts
-            working_directory: build
+            working_directory: ..
             command: |
                 mkdir /tmp/artifacts
                 mv *.deb /tmp/artifacts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/tests/cpp)
 
 if(EXISTS ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in)
     configure_file(${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in
-                ${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake @ONLY
+                ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake @ONLY
     )
-    add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake")
+    add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 endif()

--- a/pkg/deb/blksnap/blksnap-tools.manpages
+++ b/pkg/deb/blksnap/blksnap-tools.manpages
@@ -1,0 +1,1 @@
+doc/blksnap.8

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -49,13 +49,6 @@ add_executable(${TEST_PERFORMANCE} performance.cpp)
 target_link_libraries(${TEST_PERFORMANCE} PRIVATE ${TESTS_LIBS})
 target_include_directories(${TEST_PERFORMANCE} PRIVATE ./)
 
-set_target_properties(${TEST_CORRUPT} ${TEST_CBT} ${TEST_DIFF_STORAGE} ${TEST_BOUNDARY} ${TEST_PERFORMANCE}
-    PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../
-)
-
-#add_custom_target(blksnap-tests DEPENDS ${TEST_CORRUPT} ${TEST_CBT} ${TEST_DIFF_STORAGE} ${TEST_BOUNDARY} ${TEST_PERFORMANCE})
-
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../
         DESTINATION /opt/blksnap/tests
         USE_SOURCE_PERMISSIONS


### PR DESCRIPTION
- deb: add blksnap man to blksnap-tools package
- build: don't put generated uninstall file and tests binaries in source dir
- circleci: fix directory of artifacts