### PR TITLE
Only set REQ_FUA for writes

### DIFF
--- a/module/diff_io.c
+++ b/module/diff_io.c
@@ -130,7 +130,10 @@ int diff_io_do(struct diff_io *diff_io, struct diff_region *diff_region,
 	sector_t processed = 0;
 	gfp_t gfp = GFP_NOIO | (is_nowait ? GFP_NOWAIT : 0);
 	unsigned int opf = diff_io->is_write ? REQ_OP_WRITE : REQ_OP_READ;
-	unsigned op_flags = REQ_SYNC | REQ_IDLE | REQ_FUA;
+	unsigned op_flags = REQ_SYNC | REQ_IDLE;
+
+	if (diff_io->is_write)
+		op_flags |= REQ_FUA;
 
 	if (unlikely(!check_page_aligned(diff_region->sector))) {
 		pr_err("Difference storage block should be aligned to PAGE_SIZE\n");


### PR DESCRIPTION
xen-blkfront is buggy and unexpectedly handles a read with the REQ_FUA bit set as a write which causes data loss. Since the REQ_FUA bit doesn't make sense with read operations anyway, workaround the issue by only setting it for writes.