### PR TITLE
Small improvements to tests scripts

### DIFF
--- a/tests/1000-simple.sh
+++ b/tests/1000-simple.sh
@@ -34,7 +34,6 @@ mkdir -p ${MPDIR}
 # create first device
 IMAGEFILE_1=${TESTDIR}/simple_1.img
 imagefile_make ${IMAGEFILE_1} 64
-echo "new image file ${IMAGEFILE_1}"
 
 DEVICE_1=$(loop_device_attach ${IMAGEFILE_1})
 echo "new device ${DEVICE_1}"
@@ -46,7 +45,6 @@ mount ${DEVICE_1} ${MOUNTPOINT_1}
 # create second device
 IMAGEFILE_2=${TESTDIR}/simple_2.img
 imagefile_make ${IMAGEFILE_2} 128
-echo "new image file ${IMAGEFILE_2}"
 
 DEVICE_2=$(loop_device_attach ${IMAGEFILE_2})
 echo "new device ${DEVICE_2}"

--- a/tests/2000-stretch.sh
+++ b/tests/2000-stretch.sh
@@ -27,7 +27,6 @@ mkdir -p ${DIFF_STORAGE}
 # create first device
 IMAGEFILE_1=${TESTDIR}/simple_1.img
 imagefile_make ${IMAGEFILE_1} 4096
-echo "new image file ${IMAGEFILE_1}"
 
 DEVICE_1=$(loop_device_attach ${IMAGEFILE_1})
 echo "new device ${DEVICE_1}"

--- a/tests/3000-cbt.sh
+++ b/tests/3000-cbt.sh
@@ -27,7 +27,6 @@ mkdir -p ${DIFF_STORAGE}
 # create first device
 IMAGEFILE_1=${TESTDIR}/simple_1.img
 imagefile_make ${IMAGEFILE_1} 4096
-echo "new image file ${IMAGEFILE_1}"
 
 DEVICE_1=$(loop_device_attach ${IMAGEFILE_1})
 echo "new device ${DEVICE_1}"

--- a/tests/7000-destroy.sh
+++ b/tests/7000-destroy.sh
@@ -34,7 +34,6 @@ mkdir -p ${MPDIR}
 # create first device
 IMAGEFILE_1=${TESTDIR}/simple_1.img
 imagefile_make ${IMAGEFILE_1} 128
-echo "new image file ${IMAGEFILE_1}"
 
 DEVICE_1=$(loop_device_attach ${IMAGEFILE_1})
 echo "new device ${DEVICE_1}"

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -7,7 +7,7 @@ imagefile_make()
 	local FILEPATH=$1
 	local SIZE=$2
 
-	dd if=/dev/zero of=${FILEPATH} count=${SIZE} bs=1M
+	dd if=/dev/zero of=${FILEPATH} count=${SIZE} bs=1M status=none
 	mkfs.ext4 ${FILEPATH}
 }
 
@@ -62,7 +62,7 @@ generate_files()
 
 		let "SZ = ${SZ} % 100 + 8"
 		echo "file: ${FILE} size: ${SZ} KiB"
-		dd if=/dev/urandom of=${FILE} count=${SZ} oflag=direct bs=1024
+		dd if=/dev/urandom of=${FILE} count=${SZ} oflag=direct bs=1024 status=none
 		md5sum ${FILE} >> ${TARGET_DIR}/hash.md5
 	done
 	echo "generate complete"
@@ -85,7 +85,7 @@ generate_block_MB()
 
 		SZ=$((SZ + 1))
 		echo "file: ${FILE} size: "$((SZ * 1024))" KiB"
-		dd if=/dev/urandom of=${FILE} count=$((SZ * 1024)) bs=1024 oflag=direct
+		dd if=/dev/urandom of=${FILE} count=$((SZ * 1024)) bs=1024 oflag=direct status=none
 		md5sum ${FILE} >> ${TARGET_DIR}/hash.md5
 
 		ITER_SZ_MB=$((SZ + ITER_SZ_MB))

--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -9,6 +9,7 @@ imagefile_make()
 
 	dd if=/dev/zero of=${FILEPATH} count=${SIZE} bs=1M status=none
 	mkfs.ext4 ${FILEPATH}
+	echo "new image file ${FILEPATH}"
 }
 
 imagefile_cleanup()


### PR DESCRIPTION
-  tests: remove some not needed output from some dd commands

I saw that generated output of tests are very big and part of it is not
really needed.
To start decrease it I supressed all output except errors from dd
commands in imagefile_make(), generate_files() and generate_block_MB().
I also used these functions a lot in the additional tests I did outside the automatic tests scripts, FWIK output removed should not be needed.

- tests: add echo inside of imagefile_make() instead after any call of it