### PR TITLE
Update blkdev_get_by_dev calls to accommodate new holder ops argument

### DIFF
--- a/module/blksnap.h
+++ b/module/blksnap.h
@@ -3,6 +3,7 @@
 #define _UAPI_LINUX_BLK_SNAP_H
 
 #include <linux/types.h>
+#include <linux/version.h>
 
 #define BLK_SNAP_CTL "blksnap-control"
 #define BLK_SNAP_IMAGE_NAME "blksnap-image"
@@ -10,6 +11,13 @@
 
 #ifdef BLK_SNAP_MODIFICATION
 #define IOCTL_MOD 32
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+#define HOLDER_OPS , NULL
+#else
+#define HOLDER_OPS
+#endif
+
 #endif
 
 enum blk_snap_ioctl {

--- a/module/diff_area.c
+++ b/module/diff_area.c
@@ -236,7 +236,7 @@ struct diff_area *diff_area_new(dev_t dev_id, struct diff_storage *diff_storage)
 
 	pr_debug("Open device [%u:%u]\n", MAJOR(dev_id), MINOR(dev_id));
 
-	bdev = blkdev_get_by_dev(dev_id, FMODE_READ | FMODE_WRITE, NULL);
+	bdev = blkdev_get_by_dev(dev_id, FMODE_READ | FMODE_WRITE, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		int err = PTR_ERR(bdev);
 

--- a/module/diff_storage.c
+++ b/module/diff_storage.c
@@ -174,7 +174,7 @@ diff_storage_add_storage_bdev(struct diff_storage *diff_storage, dev_t dev_id)
 	struct block_device *bdev;
 	struct storage_bdev *storage_bdev;
 
-	bdev = blkdev_get_by_dev(dev_id, FMODE_READ | FMODE_WRITE, NULL);
+	bdev = blkdev_get_by_dev(dev_id, FMODE_READ | FMODE_WRITE, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		pr_err("Failed to open device. errno=%d\n",
 		       abs((int)PTR_ERR(bdev)));

--- a/module/tracker.c
+++ b/module/tracker.c
@@ -497,7 +497,7 @@ struct tracker *tracker_create_or_get(dev_t dev_id)
 	struct block_device *bdev;
 	struct tracked_device *tr_dev;
 
-	bdev = blkdev_get_by_dev(dev_id, 0, NULL);
+	bdev = blkdev_get_by_dev(dev_id, 0, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		int err = PTR_ERR(bdev);
 
@@ -565,7 +565,7 @@ int tracker_remove(dev_t dev_id)
 	pr_info("Removing device [%u:%u] from tracking\n", MAJOR(dev_id),
 		MINOR(dev_id));
 
-	bdev = blkdev_get_by_dev(dev_id, 0, NULL);
+	bdev = blkdev_get_by_dev(dev_id, 0, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		pr_info("Cannot open device [%u:%u]\n", MAJOR(dev_id),
 		       MINOR(dev_id));
@@ -631,7 +631,7 @@ int tracker_read_cbt_bitmap(dev_t dev_id, unsigned int offset, size_t length,
 	struct tracker *tracker;
 	struct block_device *bdev;
 
-	bdev = blkdev_get_by_dev(dev_id, 0, NULL);
+	bdev = blkdev_get_by_dev(dev_id, 0, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		pr_info("Cannot open device [%u:%u]\n", MAJOR(dev_id),
 		       MINOR(dev_id));
@@ -675,7 +675,7 @@ static inline void collect_cbt_info(dev_t dev_id,
 	struct block_device *bdev;
 	struct tracker *tracker;
 
-	bdev = blkdev_get_by_dev(dev_id, 0, NULL);
+	bdev = blkdev_get_by_dev(dev_id, 0, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		pr_err("Cannot open device [%u:%u]\n", MAJOR(dev_id),
 		       MINOR(dev_id));
@@ -755,7 +755,7 @@ int tracker_mark_dirty_blocks(dev_t dev_id,
 	struct tracker *tracker;
 	struct block_device *bdev;
 
-	bdev = blkdev_get_by_dev(dev_id, 0, NULL);
+	bdev = blkdev_get_by_dev(dev_id, 0, NULL HOLDER_OPS);
 	if (IS_ERR(bdev)) {
 		pr_err("Cannot open device [%u:%u]\n", MAJOR(dev_id),
 		       MINOR(dev_id));


### PR DESCRIPTION
This is necessary to build on kernel 6.5 (installed w/ today's Ubuntu 23.10 release)