### PR TITLE
[VAL-6.1] improvements to github and circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,10 +66,10 @@ jobs:
         <<: *shared
         docker:
             - image: library/ubuntu:jammy
-    ubuntu2210:
+    ubuntu2310:
         <<: *shared
         docker:
-            - image: library/ubuntu:kinetic
+            - image: library/ubuntu:mantic
 
 workflows:
   build-deb:
@@ -79,4 +79,4 @@ workflows:
       - debian12
       - ubuntu2004
       - ubuntu2204
-      - ubuntu2210
+      - ubuntu2310

--- a/.github/workflows/Kernel-module.yml
+++ b/.github/workflows/Kernel-module.yml
@@ -34,7 +34,7 @@ jobs:
             image: "library/debian:bookworm"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install packages required
         run: |

--- a/.github/workflows/Kernel-module.yml
+++ b/.github/workflows/Kernel-module.yml
@@ -32,6 +32,8 @@ jobs:
             image: "library/debian:bullseye"
           - kversion: "6.1"
             image: "library/debian:bookworm"
+          - kversion: "last stable"
+            image: "library/debian:sid"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install packages required
         run: |

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -33,7 +33,7 @@ jobs:
           - arch: s390x
           - arch: armv7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Build
         id: build

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -26,6 +26,7 @@ jobs:
     name: ${{ matrix.arch }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -40,6 +40,7 @@ jobs:
         id: build
         with:
           arch: ${{ matrix.arch }}
+          distro: bullseye
 
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}


### PR DESCRIPTION
- Bump actions/checkout from 3 to 4
- github workflow: add testing kernel module on more recent kernel version
- circleci: replace ubuntu 22.10 with ubuntu 23.10
- github workflow: on build on other archs don't stop if one job fails
- github workflow: on build on other archs restore distro bullseye