### PR TITLE
[stable-v2.0] improvements to github and circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,10 +61,10 @@ jobs:
         <<: *shared
         docker:
             - image: library/ubuntu:jammy
-    ubuntu2210:
+    ubuntu2310:
         <<: *shared
         docker:
-            - image: library/ubuntu:kinetic
+            - image: library/ubuntu:mantic
 
 workflows:
   build-deb:
@@ -74,4 +74,4 @@ workflows:
       - debian12
       - ubuntu2004
       - ubuntu2204
-      - ubuntu2210
+      - ubuntu2310

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install packages required
         run: |

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -33,7 +33,7 @@ jobs:
           - arch: s390x
           - arch: armv7
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Build
         id: build

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build_job:
     # The host should always be linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: ${{ matrix.arch }}
 
     strategy:
@@ -39,7 +39,6 @@ jobs:
         id: build
         with:
           arch: ${{ matrix.arch }}
-          distro: bullseye
 
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -26,6 +26,7 @@ jobs:
     name: ${{ matrix.arch }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64

--- a/.github/workflows/build-other-archs.yml
+++ b/.github/workflows/build-other-archs.yml
@@ -40,6 +40,7 @@ jobs:
         id: build
         with:
           arch: ${{ matrix.arch }}
+          distro: bullseye
 
           # Not required, but speeds up builds
           githubToken: ${{ github.token }}


### PR DESCRIPTION
- Bump actions/checkout from 3 to 4
- circleci: replace ubuntu 22.10 with ubuntu 23.10
- github: set 'runs-on: ubuntu-22.04' on build other archs workflow
- github workflow: on build on other archs don't stop if one job fails
- github workflow: on build on other archs restore distro bullseye