### PR TITLE
fix snapshot block device path in tests

### DIFF
--- a/tests/1000-simple.sh
+++ b/tests/1000-simple.sh
@@ -83,15 +83,15 @@ check_files ${MOUNTPOINT_1}
 echo "Check snapshots"
 IMAGE_1=${TESTDIR}/image0
 mkdir -p ${IMAGE_1}
-mount /dev/veeamblksnap-image0 ${IMAGE_1}
+mount /dev/veeamblksnapimg0 ${IMAGE_1}
 check_files ${IMAGE_1}
 
 echo "Write to snapshot"
 generate_files ${IMAGE_1} "snapshot" 3
 
 drop_cache
-umount /dev/veeamblksnap-image0
-mount /dev/veeamblksnap-image0 ${IMAGE_1}
+umount /dev/veeamblksnapimg0
+mount /dev/veeamblksnapimg0 ${IMAGE_1}
 
 check_files ${IMAGE_1}
 

--- a/tests/2000-stretch.sh
+++ b/tests/2000-stretch.sh
@@ -63,7 +63,7 @@ echo "Check snapshot before overflow."
 
 IMAGE_1=${MPDIR}/image0
 mkdir -p ${IMAGE_1}
-mount /dev/veeamblksnap-image0 ${IMAGE_1}
+mount /dev/veeamblksnapimg0 ${IMAGE_1}
 check_files ${IMAGE_1}
 
 echo "Try to make snapshot overflow."

--- a/tests/4000-diff_storage.sh
+++ b/tests/4000-diff_storage.sh
@@ -53,9 +53,9 @@ IMAGE=${MP_DIR}/image0
 mkdir -p ${IMAGE}
 
 echo "Mount image"
-mount /dev/veeamblksnap-image0 ${IMAGE}
+mount /dev/veeamblksnapimg0 ${IMAGE}
 # for XFS filesystem nouuid option needed
-#mount -o nouuid /dev/veeamblksnap-image0 ${IMAGE}
+#mount -o nouuid /dev/veeamblksnapimg0 ${IMAGE}
 
 check_files ${IMAGE}/${RELATIVE_TEST_DIR}
 

--- a/tests/5000-pullout.sh
+++ b/tests/5000-pullout.sh
@@ -75,15 +75,15 @@ check_files ${MOUNTPOINT_1}
 echo "Check snapshots"
 IMAGE_1=${TESTDIR}/image0
 mkdir -p ${IMAGE_1}
-mount /dev/veeamblksnap-image0 ${IMAGE_1}
+mount /dev/veeamblksnapimg0 ${IMAGE_1}
 check_files ${IMAGE_1}
 
 echo "Write to snapshot"
 generate_files ${IMAGE_1} "snapshot" 3
 
 drop_cache
-umount /dev/veeamblksnap-image0
-mount /dev/veeamblksnap-image0 ${IMAGE_1}
+umount /dev/veeamblksnapimg0
+mount /dev/veeamblksnapimg0 ${IMAGE_1}
 
 check_files ${IMAGE_1}
 

--- a/tests/6000-snapimage_write.sh
+++ b/tests/6000-snapimage_write.sh
@@ -57,8 +57,8 @@ else
 	END="$2"
 fi
 
-IMAGEDEVICE=/dev/veeamblksnap-image0
-IMAGEMOUNTPOINT=/mnt/veeamblksnap-image0
+IMAGEDEVICE=/dev/veeamblksnapimg0
+IMAGEMOUNTPOINT=/mnt/veeamblksnapimg0
 mkdir -p ${IMAGEMOUNTPOINT}
 
 DIFF_STORAGE="${MOUNTPOINT}/diff_storage/"

--- a/tests/simpleTest.sh
+++ b/tests/simpleTest.sh
@@ -25,7 +25,7 @@ echo "STORE_UUID: $STORE_UUID"
 SNAP_ID=$(./blksnap create-snapshot --device $SRC_DEVICE --store $STORE_UUID)
 echo "SNAP_ID: $SNAP_ID"
 
-mount "/dev/veeamblksnap-image0" $DST_MOUNT_DIR
+mount "/dev/veeamblksnapimg0" $DST_MOUNT_DIR
 SNAPSHOT_SHA=$(sha1sum "$DST_MOUNT_DIR/test_file")
 echo "ORIGINAL_SHA: $ORIGINAL_SHA"
 echo "SNAPSHOT_SHA: $SNAPSHOT_SHA"


### PR DESCRIPTION
The snapshot device path is changed from /dev/veeamblksnap-image0 to /dev/veeamblksnapimg0.

Fixes: bf92996 ("struct blk_major_name.name has a limit of 16 bytes")

#80 