### PR TITLE
[VAL-6.1.2] kernel github workflow: run every week

### DIFF
--- a/.github/workflows/Kernel-module.yml
+++ b/.github/workflows/Kernel-module.yml
@@ -12,6 +12,9 @@ on:
       - "*"
     paths:
       - "module/**"
+  # Run every week
+  schedule:
+    - cron: '0 23 1 * *'
 
 jobs:
   build-on-image:


### PR DESCRIPTION
This will help to spot build issues with new kernel versions, and also possible regression with new stable versions, even if no blksnap changes will be pushed.