### PR TITLE
[VAL-6.1.2] deb/blksnap-dkms: small improve to build-deps

### DIFF
--- a/pkg/deb/blksnap-dkms/control
+++ b/pkg/deb/blksnap-dkms/control
@@ -2,7 +2,7 @@ Source: blksnap-dkms
 Section: kernel
 Priority: optional
 Maintainer: Veeam Software Group GmbH <veeam_team@veeam.com>
-Build-Depends: debhelper (>= 9.0.0), dh-dkms | dkms
+Build-Depends: debhelper (>= 9.0.0), dh-dkms | dkms (<< 3.0.3-3~)
 Homepage: https://github.org/veeam/blksnap
 Testsuite: autopkgtest-pkg-dkms
 


### PR DESCRIPTION
add version of dh-dkms split to dkms alternative dep. to show error of missed dh-dkms on newer systems